### PR TITLE
[INTL-6] Přidání chybějícího typu zprávy Y (MarketDataRequestReject).

### DIFF
--- a/lib/fix/protocol/message_class_mapping.rb
+++ b/lib/fix/protocol/message_class_mapping.rb
@@ -21,6 +21,7 @@ module Fix
         'V' => :market_data_request,
         'W' => :market_data_snapshot,
         'X' => :market_data_incremental_refresh,
+        'Y' => :market_data_request_reject,
         'j' => :business_message_reject
       }.freeze
 

--- a/lib/fix/protocol/messages/market_data_request_reject.rb
+++ b/lib/fix/protocol/messages/market_data_request_reject.rb
@@ -1,0 +1,25 @@
+module Fix
+  module Protocol
+    module Messages
+      #
+      # A FIX market data request reject message
+      #
+      class MarketDataRequestReject < Message
+        unordered :body do
+          # common fields
+          field :app_ver_id,     tag: 1128
+          field :sender_comp_id, tag: 49,   required: true
+          field :target_comp_id, tag: 56,   required: true
+          field :target_sub_id,  tag: 57,   required: true
+          field :msg_seq_num,    tag: 34,   required: true, type: :integer
+          field :sending_time,   tag: 52,   required: true, type: :timestamp, default: proc { Time.now.utc }
+
+          field :on_behalf_of_comp_id, tag: 115
+          field :text,                 tag: 58
+          field :md_req_id,            tag: 262, required: true
+          field :md_req_rej_reason,    tag: 281
+        end
+      end
+    end
+  end
+end

--- a/lib/fix/protocol/messages/order_cancel_request.rb
+++ b/lib/fix/protocol/messages/order_cancel_request.rb
@@ -10,14 +10,16 @@ module Fix
           field :msg_seq_num,    tag: 34,   required: true, type: :integer
           field :sending_time,   tag: 52,   required: true, type: :timestamp, default: proc { Time.now.utc }
 
-          field :sender_sub_id,      tag: 50
-          field :deliver_to_comp_id, tag: 128
-          field :cl_ord_id,          tag: 11, required: true
-          field :orig_cl_ord_id,     tag: 41, required: true
-          field :side,               tag: 54, required: true
-          field :symbol,             tag: 55, required: true
-          field :transact_time,      tag: 60, required: true, type: :timestamp, default: proc { Time.now.utc }
-          field :product,            tag: 460, required: true, type: :integer, default: 4
+          field :sender_sub_id,        tag: 50
+          field :deliver_to_comp_id,   tag: 128
+          field :on_behalf_of_comp_id, tag: 115
+          field :on_behalf_of_sub_id,  tag: 116
+          field :cl_ord_id,            tag: 11, required: true
+          field :orig_cl_ord_id,       tag: 41, required: true
+          field :side,                 tag: 54, required: true
+          field :symbol,               tag: 55, required: true
+          field :transact_time,        tag: 60, required: true, type: :timestamp, default: proc { Time.now.utc }
+          field :product,              tag: 460, required: true, type: :integer, default: 4
         end
       end
     end


### PR DESCRIPTION
Chyba byla způsobena tím, že pro danou zprávu neexistovalo v knihovně mapování.

Relevantní chyba:

E, [2020-11-05T18:05:36.249825 #55439] ERROR -- : Received invalid message 8=FIX.4.3|9=146|35=Y|34=12|49=demo.fxgrid|52=20201105-17:05:36.026|56=quote.APITESTINTM.023|58=Request.Validation.Provider.CurrencyPair.NotSupported|262=17|281=3|10=222|
E, [2020-11-05T18:05:36.249883 #55439] ERROR -- :          errors: ["Unknown message type <Y>"]